### PR TITLE
[dvbtime.cpp] Unconditionally do a first sync ...

### DIFF
--- a/lib/dvb/dvbtime.cpp
+++ b/lib/dvb/dvbtime.cpp
@@ -256,18 +256,7 @@ eDVBLocalTimeHandler::eDVBLocalTimeHandler()
 	{
 		res_mgr->connectChannelAdded(sigc::mem_fun(*this,&eDVBLocalTimeHandler::DVBChannelAdded), m_chanAddedConn);
 		time_t now = time(0);
-		if ( now < 1072224000 ) // 01.01.2004
-			eDebug("[eDVBLocalTimeHandler] RTC not ready... wait for transponder time");
-		else // inform all who's waiting for valid system time..
-		{
-			eDebug("[eDVBLocalTimeHandler] Use valid Linux Time :) (RTC?)");
-			noRTC();
-			if (strncmp(mybox,"gb800solo", sizeof(mybox)) == 0 || strncmp(mybox,"gb800se", sizeof(mybox)) == 0 || strncmp(mybox,"gb800ue", sizeof(mybox)) == 0)
-				m_time_ready = false; //sorry no RTC
-			else
-			    m_time_ready = true;
-			/*emit*/ m_timeUpdated();
-		}
+		eDebug("[eDVBLocalTimeHandler] RTC not ready... wait for transponder time");
 	}
 	CONNECT(m_updateNonTunedTimer->timeout, eDVBLocalTimeHandler::updateNonTuned);
 }


### PR DESCRIPTION
... as oe-a core always has a plausible time (image build time or last shutdown/reboot), the check now < 2004 always fails and time is considered as already "synced" resp. correct.
For non-networked boxes that means they never get a correct time again.
By making the first DVB transponder time sync unconditional, non-networked boxes get a correct time again.